### PR TITLE
Support first arg only for options input

### DIFF
--- a/src/Chain.php
+++ b/src/Chain.php
@@ -158,17 +158,15 @@ class Chain
             $myInputs = array_merge($myInputs, $this->getStoredInput($use));
         }
 
-        $index = $return->getIndex();
-        if (count($myInputs) == 1) {
-            $actualReturn = $return->return(array_shift($myInputs));
-        } elseif (isset($index)) {
-            $actualReturn = $return->return($myInputs[$index]);
-        } else {
-            // Last attempt; try first element, then JSON encoded string.
-            $jsonInput = json_encode($myInputs);
-            $actualReturn = $return->return(array_shift($myInputs)) ?? $return->return($jsonInput);
+        $jsonInput = json_encode($myInputs);
+        $input = array_shift($myInputs);
+    
+        if (isset($index)) {
+            $input = $return->return($myInputs[$index]);
         }
-
+        
+        $actualReturn = $return->return($input) ?? $return->return($jsonInput);
+        
         if (!isset($actualReturn)) {
             throw new \Exception("Option {$input} does not exist.");
         }

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -160,13 +160,14 @@ class Chain
 
         $index = $return->getIndex();
         if (count($myInputs) == 1) {
-            $input = array_shift($myInputs);
+            $actualReturn = $return->return(array_shift($myInputs));
         } elseif (isset($index)) {
-            $input = $myInputs[$index];
+            $actualReturn = $return->return($myInputs[$index]);
         } else {
-            $input = json_encode($myInputs);
+            // Last attempt; try first element, then JSON encoded string.
+            $jsonInput = json_encode($myInputs);
+            $actualReturn = $return->return(array_shift($myInputs)) ?? $return->return($jsonInput);
         }
-        $actualReturn = $return->return($input);
 
         if (!isset($actualReturn)) {
             throw new \Exception("Option {$input} does not exist.");


### PR DESCRIPTION
There was an issue with passing an `Options` object as the `$return` argument for `Chain::add()` -- if the method being mocked takes default arguments but we are only passing the first argument in the test, the additional arguments will all be passed as inputs, so `Chain::buildReturn()` will look for a json encoded array rather than just the single argument.