### PR TITLE
Allow duplicate mocks in chain

### DIFF
--- a/src/Chain.php
+++ b/src/Chain.php
@@ -135,10 +135,6 @@ class Chain
         $mock = $this->getMockFor($objectClass);
 
         foreach ($this->getMethods($objectClass) as $method) {
-            if (!method_exists($objectClass, $method)) {
-                throw new \Exception("method {$method} does not exist in {$objectClass}");
-            }
-
             $mock->method($method)->willReturnCallback(fn() => $this->buildReturn(
                 $objectClass,
                 $method,
@@ -311,15 +307,12 @@ class Chain
      * @param mixed $method
      *   Method name.
      *
-     * @return string|Sequence|Options|\Exception
+     * @return string|Sequence|Options|\Exception|null
      *   The return as defined.
      */
     private function getReturn($objectClass, $method)
     {
-        if (isset($this->definitions[$objectClass][$method])) {
-            return $this->definitions[$objectClass][$method];
-        }
-        return null;
+        return $this->definitions[$objectClass][$method] ?? null;
     }
 
     /**

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -27,11 +27,6 @@ class Chain
     private $lastClass;
 
     /**
-     * Instances of already built mocks, keyed by object class.
-     */
-    private ?array $mocks = null;
-
-    /**
      * Constructor.
      *
      * @param \PHPUnit\Framework\TestCase $case
@@ -164,19 +159,8 @@ class Chain
      */
     private function getMockFor($objectClass)
     {
-        if (!isset($this->mocks[$objectClass])) {
-            $methods = $this->getMethods($objectClass);
-
-            $builder = $this->getBuilder($objectClass);
-
-            if (!empty($methods)) {
-                $builder->onlyMethods($methods);
-            }
-
-            $this->mocks[$objectClass] = $builder->getMockForAbstractClass();
-        }
-
-        return $this->mocks[$objectClass];
+        $builder = $this->getBuilder($objectClass);
+        return $builder->getMockForAbstractClass();
     }
 
     /**

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -160,6 +160,9 @@ class Chain
     private function getMockFor($objectClass)
     {
         $builder = $this->getBuilder($objectClass);
+        $methods = $this->getMethods($objectClass);
+        $builder->onlyMethods($methods);
+
         return $builder->getMockForAbstractClass();
     }
 


### PR DESCRIPTION
The $mocks[] array in Chain has disrupted the behavior of Sequence returns, because it does not rebuild the mock when one with the same class name already exists.

Testing steps:

1. Build local DKAN site
2. Add `"getdkan/mock-chain": "dev-no-mock-cache",` to project composer.json's require-dev
3. Run PHPUnit tests, confirm all pass