### PR TITLE
Support PHP 8.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,5 +176,5 @@ workflows:
             - matrix-conditions:
                   matrix:
                       parameters:
-                          version: ["7.4", "8.0", "8.1"]
+                          version: ["7.4", "8.0", "8.1", "8.2"]
                           install-flags: ["", "--prefer-lowest"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
             tag: << parameters.version >>
         parameters:
             version:
-                default: "7.4"
+                default: "8.2"
                 description: The `cimg/php` Docker image version tag.
                 type: string
             install-flags:
@@ -154,7 +154,7 @@ jobs:
             - when:
                   condition:
                       and:
-                          - equal: [ "8.1", <<parameters.version>> ]
+                          - equal: [ "8.2", <<parameters.version>> ]
                           - equal: [ "", <<parameters.install-flags>> ]
                   steps:
                       - run-phpunit-tests:
@@ -164,7 +164,7 @@ jobs:
                   condition:
                       not:
                           and:
-                              - equal: [ "8.1", <<parameters.version>> ]
+                              - equal: [ "8.2", <<parameters.version>> ]
                               - equal: [ "", <<parameters.install-flags>> ]
                   steps:
                       - run-phpunit-tests:

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Exclude build/test files from archive
+/.circleci        export-ignore
+/test             export-ignore
+/.editorconfig    export-ignore
+/.gitattributes   export-ignore
+/.gitignore       export-ignore
+/phpcs.xml        export-ignore
+/phpunit.xml      export-ignore
+/rector.php       export-ignore
+
+# Configure diff output for .php and .phar files.
+*.php diff=php

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     },
     "require-dev": {
         "rector/rector": "^0.15.17",
-        "squizlabs/php_codesniffer": "^3.7.2"
+        "squizlabs/php_codesniffer": "^3.7.2",
+        "symfony/phpunit-bridge": "^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,7 +11,7 @@
     </listeners>
     <php>
         <!-- Only display deprecations, no fails. -->
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="quiet[]=indirect&amp;quiet[]=other"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>
     </php>
     <testsuites>
         <testsuite name="all">

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,6 +6,9 @@
             <directory suffix=".php">src</directory>
         </include>
     </coverage>
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+    </listeners>
     <testsuites>
         <testsuite name="all">
             <directory>test</directory>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,6 +9,10 @@
     <listeners>
         <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
     </listeners>
+    <php>
+        <!-- Only display deprecations, no fails. -->
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+    </php>
     <testsuites>
         <testsuite name="all">
             <directory>test</directory>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,10 +9,6 @@
     <listeners>
         <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
     </listeners>
-    <php>
-        <!-- Only display deprecations, no fails. -->
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
-    </php>
     <testsuites>
         <testsuite name="all">
             <directory>test</directory>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,6 +9,10 @@
     <listeners>
         <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
     </listeners>
+    <php>
+        <!-- Only display deprecations, no fails. -->
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="quiet[]=indirect&amp;quiet[]=other"/>
+    </php>
     <testsuites>
         <testsuite name="all">
             <directory>test</directory>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,7 +10,7 @@
         <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
     </listeners>
     <php>
-        <!-- Only display deprecations, no fails. -->
+        <!-- Don't fail for external dependencies. -->
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>
     </php>
     <testsuites>

--- a/rector.php
+++ b/rector.php
@@ -3,20 +3,42 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\Core\ValueObject\PhpVersion;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
+use Rector\DeadCode\Rector\Property\RemoveUselessVarTagRector;
 use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
 use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
 
 return static function (RectorConfig $rectorConfig): void {
+
+    $rectorConfig->phpVersion(PhpVersion::PHP_74);
+
     $rectorConfig->paths([
         __DIR__ . '/src',
         __DIR__ . '/test',
     ]);
 
     $rectorConfig->sets([
+        // Please no dead code or unneeded variables.
+        SetList::DEAD_CODE,
+        // Try to figure out type hints.
+        SetList::TYPE_DECLARATION,
+        // Bring us up to PHP 7.4.
         LevelSetList::UP_TO_PHP_74,
     ]);
 
     $rectorConfig->skip([
+        // Don't throw errors on JSON parse problems. Yet.
+        // @todo Throw errors and deal with them appropriately.
         JsonThrowOnErrorRector::class,
+        // We like our tags.
+        RemoveUselessParamTagRector::class,
+        RemoveUselessReturnTagRector::class,
+        RemoveUselessVarTagRector::class,
     ]);
+
+    $rectorConfig->importNames();
+    $rectorConfig->importShortClasses(false);
 };

--- a/rector.php
+++ b/rector.php
@@ -8,35 +8,39 @@ use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
 use Rector\DeadCode\Rector\Property\RemoveUselessVarTagRector;
 use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
-use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
+use Rector\TypeDeclaration\Rector\ClassMethod\ArrayShapeFromConstantArrayReturnRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedPropertyRector;
 
 return static function (RectorConfig $rectorConfig): void {
-
-    $rectorConfig->phpVersion(PhpVersion::PHP_74);
-
     $rectorConfig->paths([
         __DIR__ . '/src',
         __DIR__ . '/test',
     ]);
 
+    // Our base version of PHP.
+    $rectorConfig->phpVersion(PhpVersion::PHP_74);
+
     $rectorConfig->sets([
+        SetList::PHP_82,
         // Please no dead code or unneeded variables.
         SetList::DEAD_CODE,
         // Try to figure out type hints.
         SetList::TYPE_DECLARATION,
-        // Bring us up to PHP 7.4.
-        LevelSetList::UP_TO_PHP_74,
     ]);
 
     $rectorConfig->skip([
         // Don't throw errors on JSON parse problems. Yet.
         // @todo Throw errors and deal with them appropriately.
         JsonThrowOnErrorRector::class,
-        // We like our tags.
+        // We like our tags. Please don't remove them.
         RemoveUselessParamTagRector::class,
         RemoveUselessReturnTagRector::class,
         RemoveUselessVarTagRector::class,
+        ArrayShapeFromConstantArrayReturnRector::class,
+        AddMethodCallBasedStrictParamTypeRector::class,
+        ReturnTypeFromStrictTypedPropertyRector::class,
     ]);
 
     $rectorConfig->importNames();

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -2,6 +2,8 @@
 
 namespace MockChain;
 
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\MockBuilder;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -20,7 +22,7 @@ class Chain
     private TestCase $testCase;
 
     private array $definitions = [];
-    private $root = null;
+    private $root;
     private array $storeIds = [];
     private array $store = [];
 
@@ -29,7 +31,7 @@ class Chain
     /**
      * Constructor.
      *
-     * @param \PHPUnit\Framework\TestCase $case
+     * @param TestCase $case
      *   As a chain is usually instantiated from inside a PHPUnit test method,
      *   this will often look like `new Chain($this)`.
      */
@@ -99,7 +101,7 @@ class Chain
     /**
      * Build a usable mock object from the chain.
      *
-     * @return \PHPUnit\Framework\MockObject\MockObject
+     * @return MockObject
      */
     public function getMock()
     {
@@ -127,10 +129,10 @@ class Chain
      *
      * @param string $objectClass
      *   Qualified class name.
-     * @return \PHPUnit\Framework\MockObject\MockObject
+     * @return MockObject
      *   A built PHPUnit mock object.
      */
-    private function build($objectClass)
+    private function build(string $objectClass)
     {
         $methods = $this->getMethods($objectClass);
 
@@ -158,10 +160,10 @@ class Chain
      * @param string $class
      *   Qualified class name.
      *
-     * @return \PHPUnit\Framework\MockObject\MockBuilder
+     * @return MockBuilder
      *   MockBuilder object.
      */
-    private function getBuilder($class)
+    private function getBuilder(string $class)
     {
         $builder = $this->testCase->getMockBuilder($class);
         $builder->disableOriginalConstructor();
@@ -225,7 +227,7 @@ class Chain
      * @return mixed
      *   The correct mocked return for the method.
      */
-    private function getReturnFromOptions($myInputs, $return)
+    private function getReturnFromOptions(array $myInputs, Options $return)
     {
         if ($use = $return->getUse()) {
             $myInputs = array_merge($myInputs, $this->getStoredInput($use));
@@ -257,7 +259,7 @@ class Chain
      * @return array
      *   Methods to be mocked.
      */
-    private function getMethods($objectClass)
+    private function getMethods(string $objectClass): array
     {
         $methods = [];
 
@@ -281,7 +283,7 @@ class Chain
      * @return string|Sequence|Options|\Exception|null
      *   The return as defined.
      */
-    private function getReturn($objectClass, $method)
+    private function getReturn(string $objectClass, string $method)
     {
         return $this->definitions[$objectClass][$method] ?? null;
     }
@@ -299,7 +301,7 @@ class Chain
      *
      * @todo Better docs for this method.
      */
-    private function getStoreId($objectClass, $method)
+    private function getStoreId(string $objectClass, string $method)
     {
         return $this->storeIds[$objectClass][$method] ?? null;
     }

--- a/src/Options.php
+++ b/src/Options.php
@@ -18,7 +18,7 @@ class Options
     /**
      * The position in the inputs array of the relevant data for this option.
      */
-    private $index = null;
+    private $index;
 
     public function __construct()
     {
@@ -55,7 +55,7 @@ class Options
         return $this;
     }
 
-    public function options()
+    public function options(): array
     {
         return array_keys($this->options);
     }

--- a/test/Anatomy/Body.php
+++ b/test/Anatomy/Body.php
@@ -6,7 +6,7 @@ class Body
 {
     private array $systems = [];
 
-    public function addSystem(System $system)
+    public function addSystem(System $system): void
     {
         $this->systems[] = $system;
     }
@@ -22,7 +22,10 @@ class Body
         return null;
     }
 
-    public function getSystems()
+    /**
+     * @return mixed[]
+     */
+    public function getSystems(): array
     {
         $systems = [];
 
@@ -33,7 +36,10 @@ class Body
         return $systems;
     }
 
-    public function getOrgans()
+    /**
+     * @return mixed[]
+     */
+    public function getOrgans(): array
     {
         $organs = [];
         /* @var $system  System */

--- a/test/Anatomy/Organ.php
+++ b/test/Anatomy/Organ.php
@@ -11,7 +11,7 @@ class Organ
         $this->name = $name;
     }
 
-    public function getName(): string
+    public function getName()
     {
         return $this->name;
     }

--- a/test/Anatomy/Organ.php
+++ b/test/Anatomy/Organ.php
@@ -11,12 +11,12 @@ class Organ
         $this->name = $name;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    public function shoutName()
+    public function shoutName(): string
     {
         return strtoupper($this->name);
     }

--- a/test/Anatomy/System.php
+++ b/test/Anatomy/System.php
@@ -12,12 +12,12 @@ class System
         $this->name = $name;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    public function addOrgan(Organ $organ)
+    public function addOrgan(Organ $organ): void
     {
         $this->organs[] = $organ;
     }
@@ -33,7 +33,7 @@ class System
         return null;
     }
 
-    public function getOrgans()
+    public function getOrgans(): array
     {
         return $this->organs;
     }

--- a/test/ChainTest.php
+++ b/test/ChainTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 class ChainTest extends TestCase
 {
 
-    public function testDocs()
+    public function testDocs(): void
     {
         $organs = (new Options())
             ->add(json_encode(["lung", 0]), "yep, the left lung")
@@ -29,7 +29,7 @@ class ChainTest extends TestCase
         $this->assertEquals("yep, the right lung", $mock->getOrganByNameAndIndex("lung", 1));
     }
 
-    public function test()
+    public function test(): void
     {
         $organNames = (new Sequence())->add('mouth')->add('stomach');
 
@@ -51,7 +51,7 @@ class ChainTest extends TestCase
         $this->assertEquals($body->getSystem('digestive')->getOrgan('mouth')->getName(), 'mouth');
     }
 
-    public function test2()
+    public function test2(): void
     {
         $organNames = (new Sequence())->add('mouth')->add('stomach');
 
@@ -75,7 +75,7 @@ class ChainTest extends TestCase
     }
 
 
-    public function test3()
+    public function test3(): void
     {
         $organs = (new Options())
             ->add('mouth', Organ::class)
@@ -101,7 +101,7 @@ class ChainTest extends TestCase
         $this->assertEquals(json_encode(['stomach']), json_encode($chain->getStoredInput('organ')));
     }
 
-    public function test4()
+    public function test4(): void
     {
         $this->expectExceptionMessage("blah");
 
@@ -115,7 +115,7 @@ class ChainTest extends TestCase
         $body->getSystem("blah");
     }
 
-    public function testNonExistentMethod()
+    public function testNonExistentMethod(): void
     {
         // CannotUseOnlyMethodsException only exists in PHPUnit 9.5+, so we
         // check whether it exists to determine which exception will be thrown
@@ -133,13 +133,13 @@ class ChainTest extends TestCase
           ->getMock();
     }
 
-    public function testUsingAdddIncorrectly()
+    public function testUsingAdddIncorrectly(): void
     {
         $this->expectExceptionMessage("You should use the add method before using addd.");
         (new Chain($this))->addd("hello");
     }
 
-    public function testNonExistentOption()
+    public function testNonExistentOption(): void
     {
         $this->expectExceptionMessage('Option digestive does not exist');
         $options = new Options();

--- a/test/OptionsTest.php
+++ b/test/OptionsTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class OptionsTest extends TestCase
 {
-    public function test()
+    public function test(): void
     {
         $options = new Options();
         $options->add("hello", "goodbye");

--- a/test/SequenceTest.php
+++ b/test/SequenceTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class SequenceTest extends TestCase
 {
-    public function test()
+    public function test(): void
     {
         $sequence = new Sequence();
         $sequence->add(null);
@@ -23,7 +23,7 @@ class SequenceTest extends TestCase
         $this->assertEquals($sequence->return(), 2);
     }
 
-    public function testSequenceThroughChain()
+    public function testSequenceThroughChain(): void
     {
         $sequence = (new Sequence())
             ->add(null)


### PR DESCRIPTION
- Adds PHP 8.2 to the testing matrix.
- Adds `.gitattributes` so packages exclude tests, etc.
- Rector adds some code quality.
- Adds `symfony/phpunit-bridge` to trigger deprecation errors.
- `composer.json` already has an upper constraint for PHP of `<9.0`

How to QA:
- Set up a DKAN development environment.
- Use this branch: `ddev composer require --dev "getdkan/mock-chain:dev-php-82 as 1.3.5"`
- Run tests: `ddev dkan-phpunit`