### PR TITLE
PHP 8.3 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
             tag: << parameters.version >>
         parameters:
             version:
-                default: "8.2"
+                default: "8.3"
                 description: The `cimg/php` Docker image version tag.
                 type: string
             install-flags:
@@ -154,7 +154,7 @@ jobs:
             - when:
                   condition:
                       and:
-                          - equal: [ "8.2", <<parameters.version>> ]
+                          - equal: [ "8.3", <<parameters.version>> ]
                           - equal: [ "", <<parameters.install-flags>> ]
                   steps:
                       - run-phpunit-tests:
@@ -164,7 +164,7 @@ jobs:
                   condition:
                       not:
                           and:
-                              - equal: [ "8.2", <<parameters.version>> ]
+                              - equal: [ "8.3", <<parameters.version>> ]
                               - equal: [ "", <<parameters.install-flags>> ]
                   steps:
                       - run-phpunit-tests:
@@ -176,5 +176,5 @@ workflows:
             - matrix-conditions:
                   matrix:
                       parameters:
-                          version: ["7.4", "8.0", "8.1", "8.2"]
+                          version: ["7.4", "8.0", "8.1", "8.2", "8.3"]
                           install-flags: ["", "--prefer-lowest"]

--- a/rector.php
+++ b/rector.php
@@ -3,27 +3,24 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Core\ValueObject\PhpVersion;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
 use Rector\DeadCode\Rector\Property\RemoveUselessVarTagRector;
 use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
 use Rector\Set\ValueObject\SetList;
-use Rector\TypeDeclaration\Rector\ClassMethod\ArrayShapeFromConstantArrayReturnRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\ArrayShapeFromConstantArrayReturnRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedPropertyRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([
         __DIR__ . '/src',
         __DIR__ . '/test',
+        __FILE__,
     ]);
 
-    // Our base version of PHP.
-    $rectorConfig->phpVersion(PhpVersion::PHP_74);
-
     $rectorConfig->sets([
-        SetList::PHP_82,
+        SetList::PHP_74,
         // Please no dead code or unneeded variables.
         SetList::DEAD_CODE,
         // Try to figure out type hints.
@@ -43,6 +40,7 @@ return static function (RectorConfig $rectorConfig): void {
         ReturnTypeFromStrictTypedPropertyRector::class,
     ]);
 
+    $rectorConfig->removeUnusedImports();
     $rectorConfig->importNames();
     $rectorConfig->importShortClasses(false);
 };


### PR DESCRIPTION
- Adds PHP 8.3 to CI matrix.
- Updates Rector config to remove unused imports.