### PR TITLE
PHP 8.4 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
             tag: << parameters.version >>
         parameters:
             version:
-                default: "8.3"
+                default: "8.4"
                 description: The `cimg/php` Docker image version tag.
                 type: string
             install-flags:
@@ -154,7 +154,7 @@ jobs:
             - when:
                   condition:
                       and:
-                          - equal: [ "8.3", <<parameters.version>> ]
+                          - equal: [ "8.4", <<parameters.version>> ]
                           - equal: [ "", <<parameters.install-flags>> ]
                   steps:
                       - run-phpunit-tests:
@@ -164,7 +164,7 @@ jobs:
                   condition:
                       not:
                           and:
-                              - equal: [ "8.3", <<parameters.version>> ]
+                              - equal: [ "8.4", <<parameters.version>> ]
                               - equal: [ "", <<parameters.install-flags>> ]
                   steps:
                       - run-phpunit-tests:
@@ -176,5 +176,5 @@ workflows:
             - matrix-conditions:
                   matrix:
                       parameters:
-                          version: ["7.4", "8.0", "8.1", "8.2", "8.3"]
+                          version: ["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]
                           install-flags: ["", "--prefer-lowest"]

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=7.4 <9.0",
         "ext-json": "*",
-        "phpunit/phpunit": "^9.6"
+        "phpunit/phpunit": ">=8.3 <8.5 || >8.5.14 <10"
     },
     "require-dev": {
         "rector/rector": "^2.0.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=7.4 <9.0",
         "ext-json": "*",
-        "phpunit/phpunit": ">=8.3 <8.5 || >8.5.14 <10"
+        "phpunit/phpunit": ">8.5.40 <10"
     },
     "require-dev": {
         "rector/rector": "^2.0.0",

--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,12 @@
     "require": {
         "php": ">=7.4 <9.0",
         "ext-json": "*",
-        "phpunit/phpunit": ">=8.3 <8.5 || >8.5.14 <10"
+        "phpunit/phpunit": "^9.6"
     },
     "require-dev": {
-        "rector/rector": "^0.15.17",
+        "rector/rector": "^2.0.0",
         "squizlabs/php_codesniffer": "^3.7.2",
-        "symfony/phpunit-bridge": "^7.0"
+        "symfony/phpunit-bridge": "^7.2"
     },
     "autoload": {
         "psr-4": {

--- a/rector.php
+++ b/rector.php
@@ -6,10 +6,8 @@ use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
 use Rector\DeadCode\Rector\Property\RemoveUselessVarTagRector;
-use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
 use Rector\Set\ValueObject\SetList;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector;
-use Rector\TypeDeclaration\Rector\ClassMethod\ArrayShapeFromConstantArrayReturnRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedPropertyRector;
 
 return static function (RectorConfig $rectorConfig): void {
@@ -28,14 +26,10 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
 
     $rectorConfig->skip([
-        // Don't throw errors on JSON parse problems. Yet.
-        // @todo Throw errors and deal with them appropriately.
-        JsonThrowOnErrorRector::class,
         // We like our tags. Please don't remove them.
         RemoveUselessParamTagRector::class,
         RemoveUselessReturnTagRector::class,
         RemoveUselessVarTagRector::class,
-        ArrayShapeFromConstantArrayReturnRector::class,
         AddMethodCallBasedStrictParamTypeRector::class,
         ReturnTypeFromStrictTypedPropertyRector::class,
     ]);

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -54,7 +54,7 @@ class Chain
      * @return Chain
      *   Updated chain object.
      */
-    public function add($objectClass, $method = null, $return = null, $storeId = null)
+    public function add($objectClass, $method = null, $return = null, $storeId = null): self
     {
         $this->lastClass = $objectClass;
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -12,7 +12,7 @@ namespace MockChain;
 class Options
 {
 
-    private $options;
+    private array $options;
     private $storeId;
 
     /**
@@ -26,7 +26,7 @@ class Options
         $this->storeId = null;
     }
 
-    public function use($storeId)
+    public function use($storeId): self
     {
         $this->storeId = $storeId;
         return $this;
@@ -37,7 +37,7 @@ class Options
         return $this->storeId;
     }
 
-    public function index($index)
+    public function index($index): self
     {
         $this->index = $index;
         return $this;
@@ -48,7 +48,7 @@ class Options
         return $this->index;
     }
 
-    public function add($option, $return)
+    public function add($option, $return): self
     {
         $option = is_array($option) ? json_encode($option) : $option;
         $this->options[$option] = $return;

--- a/src/Sequence.php
+++ b/src/Sequence.php
@@ -13,7 +13,7 @@ class Sequence
     private $sequence = [];
     private int $counter = 0;
 
-    public function add($return)
+    public function add($return): self
     {
         if (!isset($return)) {
             $this->sequence[] = new ReturnNull();


### PR DESCRIPTION
Adjust for higher PHPUnit target.
Release 2.0.0 because we'll break BC for older versions of PHPUnit.